### PR TITLE
Fixes #4 Improved error messaging for login

### DIFF
--- a/snapchat_bots/bot.py
+++ b/snapchat_bots/bot.py
@@ -17,7 +17,11 @@ class SnapchatBot(object):
         self.password = password
 
         self.client = Snapchat()
-        self.client.login(username, password)
+        result = self.client.login(username, password)
+
+        if self.client.username is None and self.client.auth_token is None:
+            self.log('Authorization Failed, status: "%s" , message "%s"' % (result['status'], result['message']))
+            raise SystemExit(1)
 
         self.current_friends = self.get_friends()
         self.added_me = self.get_added_me()


### PR DESCRIPTION
Added error message logging for the initial authorization flow. 

Example ouput:

[2015-02-28 01:08:06,611] [StorifierBot-18da] Authorization Failed, status: "-100" , message "That's not the right password. Sorry!"

[2015-02-28 00:05:12,611] [StorifierBot-18da] Authorization Failed, status: "403" , message "'The network you are connected to has been temporarily blocked because of suspicious activity"
